### PR TITLE
Update Dockerfile to use hashicorp mirror to get around rate limits

### DIFF
--- a/self-managed/infrastructure/docker/images/base/Dockerfile
+++ b/self-managed/infrastructure/docker/images/base/Dockerfile
@@ -4,7 +4,7 @@
 # ----------------- #
 
 ## Using Debian as base system
-FROM debian:latest
+FROM docker.mirror.hashicorp.services/library/debian:latest
 
 # ----------------- #
 # | SW PACKAGES   | #


### PR DESCRIPTION
The sandbox environment tries to build the consul base image using `debian:latest`. However, this is rate-limited. This PR updates the image to use HashiCorp's mirror instead (which has no rate limits)

```
root@operator:~/consul-sandbox/self-managed/infrastructure/docker/images/base# docker build .
Sending build context to Docker daemon  17.92kB
Step 1/35 : FROM debian:latest
toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```